### PR TITLE
"fix" issue #23

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "forcecloseworldloadingscreen",
   "version": "${version}",
 
-  "name": "kennytv's epic force close loading screen mod for Fabric",
+  "name": "Force Close Loading Screen",
   "description": "Force closes the level receiving and resource pack loading screen instead of having to wait for the chunks you're in to be sent",
   "authors": [
     "kennytv"
@@ -28,5 +28,11 @@
     "java": ">=17"
   },
   "suggests": {
+  },
+
+  "custom": {
+    "modmenu": {
+      "update_checker": true
+    }
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,6 +27,10 @@
     "minecraft": ">=1.20.2",
     "java": ">=17"
   },
-  "suggests": {
+  "breaks": {
+    "fastload": "*"
+  },
+  "conflicts": {
+    "optifabric": "optifabric"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,11 +28,5 @@
     "java": ">=17"
   },
   "suggests": {
-  },
-
-  "custom": {
-    "modmenu": {
-      "update_checker": true
-    }
   }
 }


### PR DESCRIPTION
No idea if you want to keep the insanely long mod name, but issue #23 happens because there is no space for the "Client" badge on Mod Menu, so it just removes the badge so the text wont spill into the rest of the menu. This PR fixes that (at least in full-screen) by ruining the mod's name by shortening it.