### PR TITLE
fix sprinting resets after respawning

### DIFF
--- a/src/main/java/eu/kennytv/forcecloseloadingscreen/mixin/MouseHandlerMixin.java
+++ b/src/main/java/eu/kennytv/forcecloseloadingscreen/mixin/MouseHandlerMixin.java
@@ -1,0 +1,34 @@
+package eu.kennytv.forcecloseloadingscreen.mixin;
+
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.MouseHandler;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MouseHandler.class)
+public class MouseHandlerMixin {
+
+    @Shadow
+    @Final
+    private Minecraft minecraft;
+
+    @Shadow
+    private boolean mouseGrabbed;
+
+    @Inject(method = "grabMouse", at = @At(value = "HEAD", target = "Lnet/minecraft/client/Minecraft;setScreen(Lnet/minecraft/client/gui/screens/Screen;)V"))
+    public void fixSprint(CallbackInfo ci) {
+        if (this.minecraft.isWindowActive()) {
+            if (this.mouseGrabbed) {
+                if (!Minecraft.ON_OSX) {
+                    KeyMapping.setAll();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/eu/kennytv/forcecloseloadingscreen/mixin/MouseHandlerMixin.java
+++ b/src/main/java/eu/kennytv/forcecloseloadingscreen/mixin/MouseHandlerMixin.java
@@ -3,7 +3,6 @@ package eu.kennytv.forcecloseloadingscreen.mixin;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.MouseHandler;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,12 +22,8 @@ public class MouseHandlerMixin {
 
     @Inject(method = "grabMouse", at = @At(value = "HEAD", target = "Lnet/minecraft/client/Minecraft;setScreen(Lnet/minecraft/client/gui/screens/Screen;)V"))
     public void fixSprint(CallbackInfo ci) {
-        if (this.minecraft.isWindowActive()) {
-            if (this.mouseGrabbed) {
-                if (!Minecraft.ON_OSX) {
-                    KeyMapping.setAll();
-                }
-            }
+        if (this.minecraft.isWindowActive() && this.mouseGrabbed && !Minecraft.ON_OSX) {
+            KeyMapping.setAll();
         }
     }
 }

--- a/src/main/resources/forcecloseloadingscreen.mixins.json
+++ b/src/main/resources/forcecloseloadingscreen.mixins.json
@@ -7,7 +7,8 @@
   ],
   "client": [
     "LoadingOverlayMixin",
-    "MinecraftMixin"
+    "MinecraftMixin",
+    "MouseHandlerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## What?
Fixes https://github.com/kennytv/kennytvs-epic-force-close-loading-screen-mod-for-fabric/issues/34.

## Where does the issue come from?
The main issue appears to be, that keys aren't properly updated on death. Vanilla seems to update them if the current screen closes (`setScreen(null)`), but only if a screen was present (`!mouseGrabbed`)
`MouseHandler#grabMouse`, which will be called whenever a `Minecraft.setScreen(null)` is called, unfortunately as the mouse was still grabbed, because the screen got skipped the function to re-check pressed keys is not called.

## How to fix?
I fixed it by calling the `KeyMapping.setAll()` inside `MouseHandler#grabMouse()` if the `mouseGrabbed` is true, that way it's guaranteed to be called. Actually just calling if it is not `Minecraft.ON_OSX`, ig this bug did not happen on OSX. Dunno if this is a valid approach, but it works (on my machine), may be incompatible with #33 